### PR TITLE
Fixed build configuration

### DIFF
--- a/fobos
+++ b/fobos
@@ -40,7 +40,7 @@ output    = libface.a
 mklib     = static
 
 [face-shared-gnu]
-template  = template-static-gnu
+template  = template-shared-gnu
 build_dir = lib
 target    = face.f90
 output    = libface.so
@@ -54,7 +54,7 @@ output    = libface.a
 mklib     = static
 
 [face-shared-intel]
-template  = template-static-intel
+template  = template-shared-intel
 build_dir = lib
 target    = face.f90
 output    = libface.so

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,7 +80,7 @@ function projectbuild () {
   fi
 
   if [ "$BUILD" == "FoBiS.py" ]; then
-    FoBiS.py build -mode static-gnu
+    FoBiS.py build -mode face-static-gnu
   elif [ "$BUILD" == "make" ]; then
     make -j 1 STATIC=yes
   elif [ "$BUILD" == "cmake" ]; then


### PR DESCRIPTION
There were a couple of issues with the build configuration. First, you were using the wrong templates for you shared library build modes in the `fobos` file. This resulted in the compiler complaining that there was no main program at link-time. Second, the build-script was calling a fobo build mode which doesn't exist.