### PR TITLE
Modern cmake targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 doc/html/
 exe/
 wiki/
+/build
 
 # special files
 get_automatic_changelog.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,20 @@ add_subdirectory(src/lib)
 # ENABLE TESTING
 #################################################################
 
-option(BUILD_TESTING "Build the testing tree." OFF)
-if(BUILD_TESTING)
-    include(CTest)
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+    set(main_project TRUE)
+else()
+    set(main_project FALSE)
+endif()
+
+include(CMakeDependentOption)
+cmake_dependent_option(BUILD_TESTING_${PROJECT_NAME}
+     "Build the testing tree for project ${PROJECT_NAME}." OFF
+     "BUILD_TESTING;NOT main_project" OFF
+)
+
+if(main_project OR BUILD_TESTING_${PROJECT_NAME})
+    enable_testing()
     add_subdirectory(src/tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
 # set export variables needed for building
 #################################################################
 
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}-targets")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 set(NAMESPACE "${PROJECT_NAME}::")
 
 #################################################################
@@ -87,7 +87,7 @@ endif()
 #################################################################
 
 include(GNUInstallDirs)
-set(project_config "${PROJECT_NAME}-config.cmake")
+set(project_config "${PROJECT_NAME}Config.cmake")
 set(cmake_files_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles")
 set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(config_build_dir "${CMAKE_CURRENT_BINARY_DIR}/${config_install_dir}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
 # The target of the library FACE is exported
 # as FACE::FACE to a package config file for FACE
 #
-# usage find_package(FACE)
-# ...
-# target_link_library(<target> FACE)
+# usage:
+#     find_package(FACE)
+#     ...
+#     target_link_library(<target> FACE)
 #
 # the config file is generatet in the build and install directories
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,28 +7,19 @@
 #
 # the config file is generatet in the build and install directories
 
-#################################################################
-# HEADER
-#################################################################
 cmake_minimum_required(VERSION 3.10...3.13)
 project(FACE VERSION 1.1.1 LANGUAGES Fortran)
 
-#################################################################
+
 # seach path for additional cmake modules
-#################################################################
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
 
-#################################################################
-# set export variables needed for building
-#################################################################
 
+# set export variables needed for building
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 set(NAMESPACE "${PROJECT_NAME}::")
 
-#################################################################
-# set variables used for compile definitions of targets
-#################################################################
-
+# set variables used for compile definitions of targets after support check
 include(CheckFortranSourceRuns)
 
 check_fortran_source_runs(
@@ -66,16 +57,12 @@ if(UCS4_SUPPORTED)
     set(ucs4_supported "UCS4_SUPPORTED")
 endif()
 
-#################################################################
-# generate the library and install instructions
-#################################################################
 
+# generate the library and install instructions
 add_subdirectory(src/lib)
 
-#################################################################
-# ENABLE TESTING
-#################################################################
 
+# testing
 if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     set(main_project TRUE)
 else()
@@ -88,15 +75,12 @@ cmake_dependent_option(BUILD_TESTING_${PROJECT_NAME}
      "BUILD_TESTING;NOT main_project" OFF
 )
 
-if(main_project OR BUILD_TESTING_${PROJECT_NAME})
+if((main_project AND BUILD_TESTING) OR BUILD_TESTING_${PROJECT_NAME})
     enable_testing()
     add_subdirectory(src/tests)
 endif()
 
-#################################################################
 # generate package config files
-#################################################################
-
 include(GNUInstallDirs)
 set(project_config "${PROJECT_NAME}Config.cmake")
 set(cmake_files_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,128 +1,124 @@
+# The target of the library FACE is exported
+# as FACE::FACE to a package config file for FACE
+#
+# usage find_package(FACE)
+# ...
+# target_link_library(<target> FACE)
+#
+# the config file is generatet in the build and install directories
+
 #################################################################
 # HEADER
 #################################################################
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7)
-PROJECT(FACE Fortran)
-
-SET(${PROJECT_NAME}_VERSION 0.0.1)
-SET(${PROJECT_NAME}_SOVERSION 1)
-SET(LIB ${PROJECT_NAME})
-
-#SET(CMAKE_VERBOSE_MAKEFILE TRUE)
+cmake_minimum_required(VERSION 3.10...3.13)
+project(FACE VERSION 1.1.1 LANGUAGES Fortran)
 
 #################################################################
-# DEFINE PATHS
+# seach path for additional cmake modules
 #################################################################
-
-SET(SRC_PATH ${CMAKE_SOURCE_DIR}/src)
-SET(LIB_PATH ${SRC_PATH}/lib)
-SET(TESTS_PATH ${SRC_PATH}/tests)
-
-#SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake/Modules/")
-
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
 
 #################################################################
-# BUILD PATHS
+# set export variables needed for building
 #################################################################
 
-SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
-SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-SET(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules)
-SET(THIRDPARTY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/thirdparty)
-INCLUDE_DIRECTORIES(${CMAKE_Fortran_MODULE_DIRECTORY})
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}-targets")
+set(NAMESPACE "${PROJECT_NAME}::")
 
 #################################################################
-# CONFIGURATION TYPES & BUILD MODE & BUILD_TESTS
+# set variables used for compile definitions of targets
 #################################################################
 
-SET(CMAKE_CONFIGURATION_TYPES DEBUG RELEASE)
-IF(NOT CMAKE_BUILD_TYPE)
-  SET(CMAKE_BUILD_TYPE DEBUG CACHE STRING
-      "Choose the type of build, options are: NONE DEBUG RELEASE"
-      FORCE)
+include(CheckFortranSourceRuns)
 
-  SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS NONE DEBUG RELEASE)
-ENDIF(NOT CMAKE_BUILD_TYPE)
+check_fortran_source_runs(
+    "program ascii_support;
+         integer, parameter :: ascii = selected_char_kind('ascii');
+         if(ascii < 0) stop 1;
+     end program ascii_support"
+    ASCII_SUPPORTED
+    SRC_EXT f90)
+if(ASCII_SUPPORTED)
+    set(ascii_supported "ASCII_SUPPORTED")
+endif()
 
-IF(NOT ${PROJECT_NAME}_ENABLE_TESTS)
-    OPTION(${PROJECT_NAME}_ENABLE_TESTS "Enable/disable tests compilation" OFF)
-ENDIF(NOT ${PROJECT_NAME}_ENABLE_TESTS)
+check_fortran_source_runs(
+    "program ascii_neq_default;
+         integer, parameter :: ascii = selected_char_kind('ascii');
+         integer, parameter :: default = selected_char_kind('default');
+         if(ascii == default) stop 1;
+     end program ascii_neq_default"
+    ASCII_NEQ_DEFAULT
+    SRC_EXT f90
+)
+if(ASCII_NEQ_DEFAULT)
+    set(ascii_neq_default "ASCII_NEQ_DEFAULT")
+endif()
+
+check_fortran_source_runs(
+    "program ucs4_support;
+         integer, parameter :: ucs4 = selected_char_kind('iso_10646');
+         if(ucs4 < 0) stop 1;
+     end program ucs4_support"
+    UCS4_SUPPORTED
+    SRC_EXT f90)
+if(UCS4_SUPPORTED)
+    set(ucs4_supported "UCS4_SUPPORTED")
+endif()
 
 #################################################################
-# FFLAGS depend on the compiler and the build type
+# generate the library and install instructions
 #################################################################
 
-GET_FILENAME_COMPONENT(Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
-
-IF(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-#   SET(MACROS "${MACROS} -DDEBUG -Dmemcheck")
-    ADD_DEFINITIONS(-DDEBUG)
-    ADD_DEFINITIONS(-Dmemcheck)
-ENDIF()
-
-ADD_DEFINITIONS(-D${CMAKE_Fortran_COMPILER_ID})
-
-message(STATUS "COMPILER INFO: ${CMAKE_Fortran_COMPILER_ID} - ${Fortran_COMPILER_NAME}")
-
-IF (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" OR Fortran_COMPILER_NAME MATCHES "gfortran*")
-  # gfortran 
-  set(FORTRAN_FLAGS "-ffree-line-length-0 -cpp -Wimplicit-interface ${EXTRA_FLAGS} ")
-  set (CMAKE_Fortran_FLAGS "${FORTRAN_FLAGS} ${MACROS} ${INCLUDES} " CACHE STRING "" FORCE)
-  set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${EXTRA_FLAGS} " CACHE STRING "" FORCE)
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-g -fbacktrace -fbounds-check -fprofile-arcs -ftest-coverage -Wimplicit-interface ${EXTRA_FLAGS} " CACHE STRING "" FORCE)
-ELSEIF (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR Fortran_COMPILER_NAME MATCHES "ifort*")
-  # ifort (untested)
-  set(FORTRAN_FLAGS "-fpp -W1 ${EXTRA_FLAGS} ")
-  set (CMAKE_Fortran_FLAGS "${FORTRAN_FLAGS} ${MACROS} ${INCLUDES}" CACHE STRING "" FORCE)
-  set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${EXTRA_FLAGS} " CACHE STRING "" FORCE)
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-O0 -traceback -g -debug all -check all -ftrapuv -warn nointerfaces ${EXTRA_FLAGS} " CACHE STRING "" FORCE)
-# A partir de CMake 3.1
-# -prof-gen:srcpos -prof-dir${PROJECT_BINARY_DIR}
-
-ELSEIF (${CMAKE_Fortran_COMPILER_ID} STREQUAL "XL" OR Fortran_COMPILER_NAME MATCHES "xlf*")
-  # xlf (untested)
-  set(FORTRAN_FLAGS "-q64 -qsuffix=f=f90:cpp=f90 ${EXTRA_FLAGS} ")
-  set (CMAKE_Fortran_FLAGS "${FORTRAN_FLAGS} ${MACROS} ${INCLUDES}" CACHE STRING "" FORCE)
-  set (CMAKE_Fortran_FLAGS_RELEASE "-O3 -qstrict ${EXTRA_FLAGS} " CACHE STRING "" FORCE)
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g -qfullpath -qkeepparm ${EXTRA_FLAGS} " CACHE STRING "" FORCE)
-ELSE ()
-  message ("No optimized Fortran compiler flags are known, we just try -O2...")
-  set (CMAKE_Fortran_FLAGS_RELEASE "-O2")
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g")
-ENDIF ()
-
-SET(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--allow-multiple-definition")
-SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--allow-multiple-definition")
-
-message (STATUS "CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
-message (STATUS "CMAKE_Fortran_FLAGS: " ${CMAKE_Fortran_FLAGS})
-message (STATUS "CMAKE_Fortran_FLAGS_RELEASE: " ${CMAKE_Fortran_FLAGS_RELEASE})
-message (STATUS "CMAKE_Fortran_FLAGS_DEBUG: " ${CMAKE_Fortran_FLAGS_DEBUG})
+add_subdirectory(src/lib)
 
 #################################################################
 # ENABLE TESTING
 #################################################################
 
-SET(BUILDNAME ${CMAKE_Fortran_COMPILER_ID}_${CMAKE_BUILD_TYPE}_MKL=${${PROJECT_NAME}_ENABLE_MKL} CACHE STRING "" )
-IF(${PROJECT_NAME}_ENABLE_TESTS)
-    ENABLE_TESTING()
-    INCLUDE(CTest)
-ENDIF()
+option(BUILD_TESTING "Build the testing tree." OFF)
+if(BUILD_TESTING)
+    include(CTest)
+    add_subdirectory(src/tests)
+endif()
 
 #################################################################
-# STATIC LIBRARIES
-#################################################################
-# Try to search first static libraries
-IF(NOT ${BUILD_SHARED_LIBS})
-    SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a ${CMAKE_FIND_LIBRARY_SUFFIXES}")
-ENDIF()
-
-#################################################################
-# ADD SOURCE SUBDIRS
+# generate package config files
 #################################################################
 
-ADD_SUBDIRECTORY(${LIB_PATH})
-IF(${PROJECT_NAME}_ENABLE_TESTS)
-  ADD_SUBDIRECTORY(${TESTS_PATH})
-ENDIF()
+include(GNUInstallDirs)
+set(project_config "${PROJECT_NAME}-config.cmake")
+set(cmake_files_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(config_build_dir "${CMAKE_CURRENT_BINARY_DIR}/${config_install_dir}")
 
+# export targets for install
+install(EXPORT ${TARGETS_EXPORT_NAME}
+    NAMESPACE
+        ${NAMESPACE}
+    DESTINATION
+        ${config_install_dir}
+    COMPONENT Development
+)
+
+# export targets into build
+export(EXPORT ${TARGETS_EXPORT_NAME}
+    NAMESPACE
+        ${NAMESPACE}
+    FILE
+        ${config_build_dir}/${TARGETS_EXPORT_NAME}.cmake
+)
+
+#create package config
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/PackageConfig.cmake.in ${cmake_files_dir}/${project_config}
+    INSTALL_DESTINATION ${config_install_dir}
+)
+install(FILES ${cmake_files_dir}/${project_config}
+    DESTINATION ${config_install_dir}
+)
+
+configure_package_config_file(cmake/PackageConfig.cmake.in ${config_build_dir}/${project_config}
+    INSTALL_DESTINATION ${config_build_dir}
+    INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/cmake/Modules/CheckFortranSourceRuns.cmake
+++ b/cmake/Modules/CheckFortranSourceRuns.cmake
@@ -1,0 +1,158 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+CheckFortranSourceRuns
+----------------------
+
+Check if given Fortran source compiles and links into an executable and can
+subsequently be run.
+
+.. command:: check_fortran_source_runs
+
+  .. code-block:: cmake
+
+    check_fortran_source_runs(<code> <resultVar>
+        [SRC_EXT <extension>])
+
+  Check that the source supplied in ``<code>`` can be compiled as a Fortran source
+  file, linked as an executable and then run. The ``<code>`` must contain at
+  least ``program; end program`` statements. If the ``<code>`` could be built and run
+  successfully, the internal cache variable specified by ``<resultVar>`` will
+  be set to 1, otherwise it will be set to an value that evaluates to boolean
+  false (e.g. an empty string or an error message).
+
+  By default, the test source file will be given a ``.F90`` file extension. The
+  ``SRC_EXT`` option can be used to override this with ``.<extension>`` instead.
+
+  The underlying check is performed by the :command:`try_run` command. The
+  compile and link commands can be influenced by setting any of the following
+  variables prior to calling ``check_fortran_source_runs()``:
+
+  ``CMAKE_REQUIRED_FLAGS``
+    Additional flags to pass to the compiler. Note that the contents of
+    :variable:`CMAKE_Fortran_FLAGS <CMAKE_<LANG>_FLAGS>` and its associated
+    configuration-specific variable are automatically added to the compiler
+    command before the contents of ``CMAKE_REQUIRED_FLAGS``.
+
+  ``CMAKE_REQUIRED_DEFINITIONS``
+    A :ref:`;-list <CMake Language Lists>` of compiler definitions of the form
+    ``-DFOO`` or ``-DFOO=bar``. A definition for the name specified by
+    ``<resultVar>`` will also be added automatically.
+
+  ``CMAKE_REQUIRED_INCLUDES``
+    A :ref:`;-list <CMake Language Lists>` of header search paths to pass to
+    the compiler. These will be the only header search paths used by
+    ``try_run()``, i.e. the contents of the :prop_dir:`INCLUDE_DIRECTORIES`
+    directory property will be ignored.
+
+  ``CMAKE_REQUIRED_LINK_OPTIONS``
+    A :ref:`;-list <CMake Language Lists>` of options to add to the link
+    command (see :command:`try_run` for further details).
+
+  ``CMAKE_REQUIRED_LIBRARIES``
+    A :ref:`;-list <CMake Language Lists>` of libraries to add to the link
+    command. These can be the name of system libraries or they can be
+    :ref:`Imported Targets <Imported Targets>` (see :command:`try_run` for
+    further details).
+
+  ``CMAKE_REQUIRED_QUIET``
+    If this variable evaluates to a boolean true value, all status messages
+    associated with the check will be suppressed.
+
+  The check is only performed once, with the result cached in the variable
+  named by ``<resultVar>``. Every subsequent CMake run will re-use this cached
+  value rather than performing the check again, even if the ``<code>`` changes.
+  In order to force the check to be re-evaluated, the variable named by
+  ``<resultVar>`` must be manually removed from the cache.
+
+#]=======================================================================]
+
+include_guard(GLOBAL)
+
+macro(CHECK_Fortran_SOURCE_RUNS SOURCE VAR)
+  if(NOT DEFINED "${VAR}")
+    set(_SRC_EXT)
+    set(_key)
+    foreach(arg ${ARGN})
+      if("${arg}" MATCHES "^(SRC_EXT)$")
+        set(_key "${arg}")
+      elseif(_key)
+        list(APPEND _${_key} "${arg}")
+      else()
+        message(FATAL_ERROR "Unknown argument:\n  ${arg}\n")
+      endif()
+    endforeach()
+    if(NOT _SRC_EXT)
+      set(_SRC_EXT F90)
+    endif()
+    set(MACRO_CHECK_FUNCTION_DEFINITIONS
+      "-D${VAR} ${CMAKE_REQUIRED_FLAGS}")
+    if(CMAKE_REQUIRED_LINK_OPTIONS)
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LINK_OPTIONS
+        LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS})
+    else()
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LINK_OPTIONS)
+    endif()
+    if(CMAKE_REQUIRED_LIBRARIES)
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LIBRARIES
+        LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+    else()
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_LIBRARIES)
+    endif()
+    if(CMAKE_REQUIRED_INCLUDES)
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_INCLUDES
+        "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}")
+    else()
+      set(CHECK_Fortran_SOURCE_COMPILES_ADD_INCLUDES)
+    endif()
+    file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.${_SRC_EXT}"
+      "${SOURCE}\n")
+
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Performing Test ${VAR}")
+    endif()
+    try_run(${VAR}_EXITCODE ${VAR}_COMPILED
+      ${CMAKE_BINARY_DIR}
+      ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.${_SRC_EXT}
+      COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+      ${CHECK_Fortran_SOURCE_COMPILES_ADD_LINK_OPTIONS}
+      ${CHECK_Fortran_SOURCE_COMPILES_ADD_LIBRARIES}
+      CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
+      -DCMAKE_SKIP_RPATH:BOOL=${CMAKE_SKIP_RPATH}
+      "${CHECK_Fortran_SOURCE_COMPILES_ADD_INCLUDES}"
+      COMPILE_OUTPUT_VARIABLE OUTPUT)
+
+    # if it did not compile make the return value fail code of 1
+    if(NOT ${VAR}_COMPILED)
+      set(${VAR}_EXITCODE 1)
+    endif()
+    # if the return value was 0 then it worked
+    if("${${VAR}_EXITCODE}" EQUAL 0)
+      set(${VAR} 1 CACHE INTERNAL "Test ${VAR}")
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${VAR} - Success")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+        "Performing Fortran SOURCE FILE Test ${VAR} succeeded with the following output:\n"
+        "${OUTPUT}\n"
+        "Return value: ${${VAR}}\n"
+        "Source file was:\n${SOURCE}\n")
+    else()
+      if(CMAKE_CROSSCOMPILING AND "${${VAR}_EXITCODE}" MATCHES  "FAILED_TO_RUN")
+        set(${VAR} "${${VAR}_EXITCODE}")
+      else()
+        set(${VAR} "" CACHE INTERNAL "Test ${VAR}")
+      endif()
+
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${VAR} - Failed")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Performing Fortran SOURCE FILE Test ${VAR} failed with the following output:\n"
+        "${OUTPUT}\n"
+        "Return value: ${${VAR}_EXITCODE}\n"
+        "Source file was:\n${SOURCE}\n")
+    endif()
+  endif()
+endmacro()

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(CMAKE_Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUD
 
 set(LIB FACE)
 add_library(${LIB} face.F90)
-add_library(${NAMESPACE}::${LIB} ALIAS ${LIB})
+add_library(${NAMESPACE}${LIB} ALIAS ${LIB})
 
 target_include_directories(${LIB}
     INTERFACE

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,13 +1,45 @@
 #################################################################
-# Search F90 files recursively in all subdirs
+# set type specific output defaults
 #################################################################
+include(GNUInstallDirs)
 
-FILE(GLOB_RECURSE LIB_SRC *.f90 *.F90 *.c)
-SET(LIB_SRC ${LIB_SRC} PARENT_SCOPE)
+SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+SET(CMAKE_Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
 
-#################################################################
-# Library target
-#################################################################
-ADD_LIBRARY(${LIB} ${LIB_SRC})
+set(LIB FACE)
+add_library(${LIB} face.F90)
+add_library(${NAMESPACE}::${LIB} ALIAS ${LIB})
 
-SET_TARGET_PROPERTIES(${LIB} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION} SOVERSION ${${PROJECT_NAME}_SOVERSION})
+target_include_directories(${LIB}
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
+)
+
+target_compile_definitions(${LIB}
+    PRIVATE
+        ${ascii_supported}
+        ${ascii_neq_default}
+        ${ucs4_supported}
+)
+
+set_target_properties(${LIB} PROPERTIES
+    VERSION
+        ${PROJECT_VERSION}
+    SOVERSION
+        ${PROJECT_VERSION_MAJOR}
+)
+
+# installation and export of targets
+install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+    COMPONENT Developement
+)
+
+install(TARGETS ${LIB} EXPORT ${TARGETS_EXPORT_NAME}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT RuntimeLibraries
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,12 +1,10 @@
-#################################################################
 # set type specific output defaults
-#################################################################
 include(GNUInstallDirs)
 
 SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
-SET(CMAKE_Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+SET(CMAKE_Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/modules")
 
 set(LIB FACE)
 add_library(${LIB} face.F90)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+include(GNUInstallDirs)
+
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tests/${CMAKE_INSTALL_BINDIR}")
+
+function(add_face_test test_src libraries)
+    get_filename_component(test_name ${test_src} NAME_WE)
+
+    add_executable(${test_name} ${test_src})
+    foreach(lib IN LISTS libraries)
+        target_link_libraries(${test_name} ${lib})
+    endforeach()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endfunction()
+
+foreach(face_test
+    face_test_basic.f90
+    face_test_colors.f90
+    face_test_styles.f90
+    face_test_ucs4.F90
+)
+    add_face_test(${face_test} FACE)
+endforeach()
+
+target_compile_definitions(face_test_ucs4
+    PRIVATE
+        ${ucs4_supported})


### PR DESCRIPTION
Split the CMakeLists.txt file into one main CMakeLists.txt and additional CMakeLists.txt files for the testing and library subdirectories. Use "modern" CMake with only targets and target properties, which are also exported into the build and install tree.

Keep the output and build behaviour of the old CMake build process.

Add testing possibility.
Automatically check if different Fortran kinds are supported by the used compiler.